### PR TITLE
Mod: arg name to supplement-equation

### DIFF
--- a/jaconf/README.md
+++ b/jaconf/README.md
@@ -62,7 +62,7 @@ This is a template for **academic conference papers in Japanese**.
   - `supplement-image`: 図タイトルの接頭辞
   - `supplement-table`: 表タイトルの接頭辞
   - `supplement-separator`: 図表の接頭辞とタイトルの区切り文字
-  - `supplement-equation-ref`: 本文中で引用する際に、数式番号につける接頭辞
+  - `supplement-equation`: 本文中で引用する際に、数式番号につける接頭辞
 - 番号付け　Numbering
   - `numbering-headings`: 本文の見出し番号の体裁
   - `numbering-equation`: 式番号の体裁
@@ -117,7 +117,7 @@ This is a template for **academic conference papers in Japanese**.
   supplement-image: [図],
   supplement-table: [表],
   supplement-separator: [: ],
-  supplement-equation-ref: [],  // 式、Eq. など
+  supplement-equation: [],  // 式、Eq. など
   // 番号付け Numbering
   numbering-headings: "1.1",
   numbering-equation: "(1)",

--- a/jaconf/lib.typ
+++ b/jaconf/lib.typ
@@ -54,7 +54,7 @@
   supplement-image: [図],
   supplement-table: [表],
   supplement-separator: [: ],
-  supplement-equation-ref: [],  // 式、Eq. など
+  supplement-equation: [],  // 式、Eq. など
   // 番号付け Numbering
   numbering-headings: "1.1",
   numbering-equation: "(1)",
@@ -97,7 +97,7 @@
     let el = it.element
     if el != none and el.func() == eq {
       let num = numbering(el.numbering, ..counter(eq).at(el.location()))
-      link(el.location(), [#supplement-equation-ref #num])
+      link(el.location(), [#supplement-equation #num])
     }
     // Sections -> n章m節l項.
     // Appendix -> 付録A.

--- a/jaconf/template/main.typ
+++ b/jaconf/template/main.typ
@@ -47,7 +47,7 @@
   supplement-image: [図],
   supplement-table: [表],
   supplement-separator: [: ],
-  supplement-equation-ref: [],  // 式、Eq. など
+  supplement-equation: [],  // 式、Eq. など
   // 番号付け Numbering
   numbering-headings: "1.1",
   numbering-equation: "(1)",


### PR DESCRIPTION
関連：
- #34 
- #37

@Tomoya-Oku 

度々すみません。実装いただいた「引用のときのみ接頭辞をつける」という機能は、公式ドキュメント通りの動作でありました。
https://typst.app/docs/reference/math/equation/#parameters-supplement

こちらの確認不足で二転三転して申し訳ありませんが、
`supplement-equation-ref`から`supplement-equation`に変更しようと思います。

READMEでは`本文中で引用する際に、数式番号につける接頭辞`と記載しており、当初の懸念点であった誤解の発生も軽減できているかなと思いました。

以上、いかがでしょうか？